### PR TITLE
#7 Dto, Entity 변환 로직 위치 변경

### DIFF
--- a/user-api/src/main/java/com/sleepwell/userapi/accommodation/controller/AccommodationController.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/accommodation/controller/AccommodationController.java
@@ -28,7 +28,7 @@ public class AccommodationController {
     @GetMapping
     public List<AccommodationInfoDto> findAccommodation(@RequestBody AccommodationSearchDto accommodationSearchDto) {
         return accommodationService.findAccommodation(accommodationSearchDto).stream()
-                .map(Accommodation::toAccommodationInfoDto)
+                .map(AccommodationInfoDto::toDto)
                 .collect(Collectors.toList());
     }
 
@@ -38,6 +38,6 @@ public class AccommodationController {
     @GetMapping("/{accommodationId}")
     public AccommodationDetailInfoDto getAccommodation(@PathVariable(name = "accommodationId") Long accommodationId) {
          Accommodation accommodation = accommodationService.getAccommodation(accommodationId);
-        return accommodation.toAccommodationDetailInfo();
+        return AccommodationDetailInfoDto.toDto(accommodation);
     }
 }

--- a/user-api/src/main/java/com/sleepwell/userapi/accommodation/controller/AccommodationController.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/accommodation/controller/AccommodationController.java
@@ -28,7 +28,7 @@ public class AccommodationController {
     @GetMapping
     public List<AccommodationInfoDto> findAccommodation(@RequestBody AccommodationSearchDto accommodationSearchDto) {
         return accommodationService.findAccommodation(accommodationSearchDto).stream()
-                .map(AccommodationInfoDto::toDto)
+                .map(AccommodationInfoDto::fromEntity)
                 .collect(Collectors.toList());
     }
 
@@ -38,6 +38,6 @@ public class AccommodationController {
     @GetMapping("/{accommodationId}")
     public AccommodationDetailInfoDto getAccommodation(@PathVariable(name = "accommodationId") Long accommodationId) {
          Accommodation accommodation = accommodationService.getAccommodation(accommodationId);
-        return AccommodationDetailInfoDto.toDto(accommodation);
+        return AccommodationDetailInfoDto.fromEntity(accommodation);
     }
 }

--- a/user-api/src/main/java/com/sleepwell/userapi/accommodation/dto/AccommodationDetailInfoDto.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/accommodation/dto/AccommodationDetailInfoDto.java
@@ -1,5 +1,6 @@
 package com.sleepwell.userapi.accommodation.dto;
 
+import com.sleepwell.userapi.accommodation.entity.Accommodation;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -36,5 +37,21 @@ public class AccommodationDetailInfoDto {
     private final Integer maximumNumberOfGuest;
 
     private final String description;
+
+    public static AccommodationDetailInfoDto toDto(Accommodation accommodation) {
+        return AccommodationDetailInfoDto.builder()
+                .accommodationId(accommodation.getId())
+                .accommodationName(accommodation.getAccommodationName())
+                .price(accommodation.getPrice())
+                .accommodationType(accommodation.getAccommodationType())
+                .location(accommodation.getLocation())
+                .checkInDate(accommodation.getCheckInDate())
+                .checkOutDate(accommodation.getCheckOutDate())
+                .checkInTime(accommodation.getCheckInTime())
+                .checkOutTime(accommodation.getCheckOutTime())
+                .maximumNumberOfGuest(accommodation.getMaximumNumberOfGuest())
+                .description(accommodation.getDescription())
+                .build();
+    }
 
 }

--- a/user-api/src/main/java/com/sleepwell/userapi/accommodation/dto/AccommodationDetailInfoDto.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/accommodation/dto/AccommodationDetailInfoDto.java
@@ -38,7 +38,7 @@ public class AccommodationDetailInfoDto {
 
     private final String description;
 
-    public static AccommodationDetailInfoDto toDto(Accommodation accommodation) {
+    public static AccommodationDetailInfoDto fromEntity(Accommodation accommodation) {
         return AccommodationDetailInfoDto.builder()
                 .accommodationId(accommodation.getId())
                 .accommodationName(accommodation.getAccommodationName())

--- a/user-api/src/main/java/com/sleepwell/userapi/accommodation/dto/AccommodationInfoDto.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/accommodation/dto/AccommodationInfoDto.java
@@ -1,5 +1,6 @@
 package com.sleepwell.userapi.accommodation.dto;
 
+import com.sleepwell.userapi.accommodation.entity.Accommodation;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,4 +18,14 @@ public class AccommodationInfoDto {
 
     private final int maximumNumberOfGuest;
 
+
+    public static AccommodationInfoDto toDto(Accommodation accommodation) {
+        return AccommodationInfoDto.builder()
+                .accommodationName(accommodation.getAccommodationName())
+                .accommodationType(accommodation.getAccommodationType())
+                .price(accommodation.getPrice())
+                .location(accommodation.getLocation())
+                .maximumNumberOfGuest(accommodation.getMaximumNumberOfGuest())
+                .build();
+    }
 }

--- a/user-api/src/main/java/com/sleepwell/userapi/accommodation/dto/AccommodationInfoDto.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/accommodation/dto/AccommodationInfoDto.java
@@ -19,7 +19,7 @@ public class AccommodationInfoDto {
     private final int maximumNumberOfGuest;
 
 
-    public static AccommodationInfoDto toDto(Accommodation accommodation) {
+    public static AccommodationInfoDto fromEntity(Accommodation accommodation) {
         return AccommodationInfoDto.builder()
                 .accommodationName(accommodation.getAccommodationName())
                 .accommodationType(accommodation.getAccommodationType())

--- a/user-api/src/main/java/com/sleepwell/userapi/accommodation/entity/Accommodation.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/accommodation/entity/Accommodation.java
@@ -1,7 +1,5 @@
 package com.sleepwell.userapi.accommodation.entity;
 
-import com.sleepwell.userapi.accommodation.dto.AccommodationDetailInfoDto;
-import com.sleepwell.userapi.accommodation.dto.AccommodationInfoDto;
 import com.sleepwell.userapi.member.entity.Member;
 import com.sleepwell.userapi.reservation.entity.Reservation;
 import lombok.Getter;
@@ -53,31 +51,5 @@ public class Accommodation {
         this.checkOutTime = checkOutTime;
         this.maximumNumberOfGuest = maximumNumberOfGuest;
         this.description = description;
-    }
-
-    public AccommodationInfoDto toAccommodationInfoDto() {
-        return AccommodationInfoDto.builder()
-                .accommodationName(this.accommodationName)
-                .accommodationType(this.accommodationType)
-                .price(this.price)
-                .location(this.location)
-                .maximumNumberOfGuest(this.maximumNumberOfGuest)
-                .build();
-    }
-
-    public AccommodationDetailInfoDto toAccommodationDetailInfo() {
-        return AccommodationDetailInfoDto.builder()
-                .accommodationId(this.id)
-                .accommodationName(this.accommodationName)
-                .price(this.price)
-                .accommodationType(this.accommodationType)
-                .location(this.location)
-                .checkInDate(this.checkInDate)
-                .checkOutDate(this.checkOutDate)
-                .checkInTime(this.checkInTime)
-                .checkOutTime(checkOutTime)
-                .maximumNumberOfGuest(this.maximumNumberOfGuest)
-                .description(this.description)
-                .build();
     }
 }

--- a/user-api/src/main/java/com/sleepwell/userapi/reservation/controller/ReservationController.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/reservation/controller/ReservationController.java
@@ -24,7 +24,7 @@ public class ReservationController {
      */
     @PostMapping
     public ReservationDetailInfoDto createReservation(@RequestBody ReservationRequestDto reservationRequestDto) {
-        Reservation reservation = reservationRequestDto.toEntity();
+        Reservation reservation = reservationRequestDto.toReservation();
         Reservation createdReservation = reservationService.createReservation(reservation, reservationRequestDto.getAccommodationId(), reservationRequestDto.getGuestId());
         return ReservationDetailInfoDto.toDto(createdReservation);
     }

--- a/user-api/src/main/java/com/sleepwell/userapi/reservation/controller/ReservationController.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/reservation/controller/ReservationController.java
@@ -24,9 +24,9 @@ public class ReservationController {
      */
     @PostMapping
     public ReservationDetailInfoDto createReservation(@RequestBody ReservationRequestDto reservationRequestDto) {
-        Reservation reservation = reservationRequestDto.toReservation();
+        Reservation reservation = reservationRequestDto.toEntity();
         Reservation createdReservation = reservationService.createReservation(reservation, reservationRequestDto.getAccommodationId(), reservationRequestDto.getGuestId());
-        return ReservationDetailInfoDto.toDto(createdReservation);
+        return ReservationDetailInfoDto.fromEntity(createdReservation);
     }
 
     /**
@@ -35,6 +35,6 @@ public class ReservationController {
     @GetMapping("/{reservationId}")
     public ReservationDetailInfoDto getReservation(@PathVariable(name = "reservationId") Long reservationId) {
         Reservation reservation = reservationService.getReservation(reservationId);
-        return ReservationDetailInfoDto.toDto(reservation);
+        return ReservationDetailInfoDto.fromEntity(reservation);
     }
 }

--- a/user-api/src/main/java/com/sleepwell/userapi/reservation/controller/ReservationController.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/reservation/controller/ReservationController.java
@@ -26,7 +26,7 @@ public class ReservationController {
     public ReservationDetailInfoDto createReservation(@RequestBody ReservationRequestDto reservationRequestDto) {
         Reservation reservation = reservationRequestDto.toEntity();
         Reservation createdReservation = reservationService.createReservation(reservation, reservationRequestDto.getAccommodationId(), reservationRequestDto.getGuestId());
-        return createdReservation.toReservationDetailInfoDto();
+        return ReservationDetailInfoDto.toDto(createdReservation);
     }
 
     /**
@@ -35,6 +35,6 @@ public class ReservationController {
     @GetMapping("/{reservationId}")
     public ReservationDetailInfoDto getReservation(@PathVariable(name = "reservationId") Long reservationId) {
         Reservation reservation = reservationService.getReservation(reservationId);
-        return reservation.toReservationDetailInfoDto();
+        return ReservationDetailInfoDto.toDto(reservation);
     }
 }

--- a/user-api/src/main/java/com/sleepwell/userapi/reservation/dto/ReservationDetailInfoDto.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/reservation/dto/ReservationDetailInfoDto.java
@@ -46,7 +46,7 @@ public class ReservationDetailInfoDto {
 
     private final String reservationStatus;
 
-    public static ReservationDetailInfoDto toDto(Reservation reservation) {
+    public static ReservationDetailInfoDto fromEntity(Reservation reservation) {
         return ReservationDetailInfoDto.builder()
                 .reservationId(reservation.getId())
                 .accommodationId(reservation.getAccommodation().getId())

--- a/user-api/src/main/java/com/sleepwell/userapi/reservation/dto/ReservationDetailInfoDto.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/reservation/dto/ReservationDetailInfoDto.java
@@ -1,5 +1,6 @@
 package com.sleepwell.userapi.reservation.dto;
 
+import com.sleepwell.userapi.reservation.entity.Reservation;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -41,7 +42,27 @@ public class ReservationDetailInfoDto {
     @DateTimeFormat(pattern = "hh:mm")
     private final LocalTime checkOutTime;
 
-    private final int guests;
+    private final int numberOfGuest;
 
     private final String reservationStatus;
+
+    public static ReservationDetailInfoDto toDto(Reservation reservation) {
+        return ReservationDetailInfoDto.builder()
+                .reservationId(reservation.getId())
+                .accommodationId(reservation.getAccommodation().getId())
+                .accommodationName(reservation.getAccommodation().getAccommodationName())
+                .hostName(reservation.getAccommodation().getHost().getName())
+                .guestName(reservation.getGuest().getName())
+                .price(reservation.getAccommodation().getPrice())
+                .paymentType(reservation.getPaymentType())
+                .accommodationType(reservation.getAccommodation().getAccommodationType())
+                .location(reservation.getAccommodation().getLocation())
+                .checkInDate(reservation.getCheckInDate())
+                .checkOutDate(reservation.getCheckOutDate())
+                .checkInTime(reservation.getAccommodation().getCheckInTime())
+                .checkOutTime(reservation.getAccommodation().getCheckOutTime())
+                .numberOfGuest(reservation.getNumberOfGuest())
+                .reservationStatus(reservation.getReservationStatus())
+                .build();
+    }
 }

--- a/user-api/src/main/java/com/sleepwell/userapi/reservation/dto/ReservationRequestDto.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/reservation/dto/ReservationRequestDto.java
@@ -31,7 +31,7 @@ public class ReservationRequestDto {
 
     private final int numberOfGuest;
 
-    public Reservation toReservation() {
+    public Reservation toEntity() {
         return new Reservation(this.paymentType, checkInDate, checkOutDate, numberOfGuest);
     }
 }

--- a/user-api/src/main/java/com/sleepwell/userapi/reservation/dto/ReservationRequestDto.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/reservation/dto/ReservationRequestDto.java
@@ -31,7 +31,7 @@ public class ReservationRequestDto {
 
     private final int numberOfGuest;
 
-    public Reservation toEntity() {
+    public Reservation toReservation() {
         return new Reservation(this.paymentType, checkInDate, checkOutDate, numberOfGuest);
     }
 }

--- a/user-api/src/main/java/com/sleepwell/userapi/reservation/entity/Reservation.java
+++ b/user-api/src/main/java/com/sleepwell/userapi/reservation/entity/Reservation.java
@@ -2,7 +2,6 @@ package com.sleepwell.userapi.reservation.entity;
 
 import com.sleepwell.userapi.accommodation.entity.Accommodation;
 import com.sleepwell.userapi.member.entity.Member;
-import com.sleepwell.userapi.reservation.dto.ReservationDetailInfoDto;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -40,25 +39,5 @@ public class Reservation {
         this.setAccommodation(accommodation);
         guest.getReservations().add(this);
         accommodation.getReservations().add(this);
-    }
-
-    public ReservationDetailInfoDto toReservationDetailInfoDto() {
-        return ReservationDetailInfoDto.builder()
-                .reservationId(this.id)
-                .accommodationId(this.accommodation.getId())
-                .accommodationName(this.accommodation.getAccommodationName())
-                .hostName(this.accommodation.getHost().getName())
-                .guestName(this.guest.getName())
-                .price(this.accommodation.getPrice())
-                .paymentType(this.paymentType)
-                .accommodationType(this.accommodation.getAccommodationType())
-                .location(this.accommodation.getLocation())
-                .checkInDate(this.checkInDate)
-                .checkOutDate(this.checkOutDate)
-                .checkInTime(this.accommodation.getCheckInTime())
-                .checkOutTime(this.accommodation.getCheckOutTime())
-                .guests(this.numberOfGuest)
-                .reservationStatus(this.reservationStatus)
-                .build();
     }
 }


### PR DESCRIPTION
**작업 내용**
- dto와 entity 변환로직의 위치를 dto로 통일하였습니다.
    - 이전처럼 엔티티 쪽에 변환 로직이 작성되면, 2개 이상의 엔티티 데이터를 담은 dto 객체를 변환할 때는 toDTO에 다른 엔티티를 파라미터로 넣어야하고, 어떤 엔티티에 해당 dto 변환로직이 들어가야하는지 일관성을 제공하지 못하는 문제가 있었습니다.
    - dto 쪽에 변환 로직이 작성됨으로써, 여러 엔티티가 필요한 dto 변환작업 시 파라미터를 통해 해당 엔티티의 정보를 담는 방식으로 일관적인 위치와 방식으로 변환 로직이 작성될 수 있다는 장점이 생겨 해당 방식으로 전환하였습니다.